### PR TITLE
Change julia version from 1.6 to 1 in CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
This PR changes the hard-coded `1.6` in julia versions in `CI.yml`.