### PR TITLE
Data Constructors for Fixed Effects

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -164,11 +164,6 @@ apply_schema(t, schema) = t
 apply_schema(terms::TupleTerm, schema) = reduce(+, apply_schema.(terms, Ref(schema)))
 
 apply_schema(t::Term, schema::Schema) = schema[t]
-function apply_schema(ft::FormulaTerm, schema::Schema)
-    return FormulaTerm(
-        apply_schema(ft.lhs, schema), collect_matrix_terms(apply_schema(ft.rhs, schema))
-    )
-end
 function apply_schema(it::InteractionTerm, schema::Schema)
     return InteractionTerm(apply_schema(it.terms, schema))
 end

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -177,8 +177,7 @@ random-effects terms.
 """
 function collect_matrix_terms(ts::TupleTerm)
     ismat = collect(is_matrix_term.(ts))
-return all(ismat) ? MatrixTerm(ts) : MatrixTerm(ts[ismat])
-    else
+    return all(ismat) ? MatrixTerm(ts) : MatrixTerm(ts[ismat])
 end
 
 function collect_matrix_terms(t::T) where {T<:AbstractTerm}

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -179,11 +179,9 @@ function collect_matrix_terms(ts::TupleTerm)
     ismat = collect(is_matrix_term.(ts))
     if all(ismat)
         MatrixTerm(ts)
-    elseif any(ismat)
-        matterms = ts[ismat]
-        (MatrixTerm(ts[ismat]), ts[.!ismat]...)
     else
-        ts
+        matterms = ts[ismat]
+        MatrixTerm(ts[ismat])
     end
 end
 
@@ -205,8 +203,10 @@ matrix terms, this defaults to `true` for any `AbstractTerm`.
 An example of a non-matrix term is a random-effect term
 [`TuringGLM.RandomEffectTerm`](@ref).
 """
-is_matrix_term(::T) where {T} = is_matrix_term(T)
-is_matrix_term(::Type{<:AbstractTerm}) = true
+is_matrix_term(::InterceptTerm) = false
+is_matrix_term(::ConstantTerm) = false
+# fallback
+is_matrix_term(::AbstractTerm) = true
 
 extract_symbols(x) = Symbol[]
 extract_symbols(x::Symbol) = [x]

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -177,12 +177,8 @@ random-effects terms.
 """
 function collect_matrix_terms(ts::TupleTerm)
     ismat = collect(is_matrix_term.(ts))
-    if all(ismat)
-        MatrixTerm(ts)
+return all(ismat) ? MatrixTerm(ts) : MatrixTerm(ts[ismat])
     else
-        matterms = ts[ismat]
-        MatrixTerm(ts[ismat])
-    end
 end
 
 function collect_matrix_terms(t::T) where {T<:AbstractTerm}

--- a/test/data_constructors.jl
+++ b/test/data_constructors.jl
@@ -51,37 +51,24 @@
         @testset "NamedTuples" begin
             f = @formula y_int ~ 0 + x_float + x_cat
             X = TuringGLM.data_fixed_effects(f, nt_str)
-            @test X == [
+            expected = [
                 1.1 0.0 0.0 0.0
                 2.3 1.0 0.0 0.0
                 3.14 0.0 1.0 0.0
                 3.65 0.0 0.0 1.0
             ]
+            @test X == expected
             f = @formula y_int ~ 1 + x_float + x_cat
             X = TuringGLM.data_fixed_effects(f, nt_str)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
 
             f = @formula y_float ~ 0 + x_float + x_cat
             X = TuringGLM.data_fixed_effects(f, nt_str)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
+            
             f = @formula y_float ~ 1 + x_float + x_cat
             X = TuringGLM.data_fixed_effects(f, nt_str)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
 
             f = @formula y_int ~ 0 + x_float + x_cat_ordered
             X = TuringGLM.data_fixed_effects(f, nt_cat)

--- a/test/data_constructors.jl
+++ b/test/data_constructors.jl
@@ -3,52 +3,52 @@
         @testset "NamedTuples" begin
             expected = [2, 3, 4, 5]
             f = @formula y_int ~ 0 + x_float + x_cat
-            y = TuringGLM.data_response(f, nt_str)
+            y = T.data_response(f, nt_str)
             @test y == expected
-            y = TuringGLM.data_response(f, nt_cat)
+            y = T.data_response(f, nt_cat)
             @test y == expected
             f = @formula y_int ~ 1 + x_float + x_cat
-            y = TuringGLM.data_response(f, nt_str)
+            y = T.data_response(f, nt_str)
             @test y == expected
-            y = TuringGLM.data_response(f, nt_cat)
+            y = T.data_response(f, nt_cat)
             @test y == expected
 
             expected = [2.3, 3.4, 4.5, 5.4]
             f = @formula y_float ~ 0 + x_float + x_cat
-            y = TuringGLM.data_response(f, nt_str)
+            y = T.data_response(f, nt_str)
             @test y == expected
-            y = TuringGLM.data_response(f, nt_cat)
+            y = T.data_response(f, nt_cat)
             @test y == expected
             f = @formula y_float ~ 1 + x_float + x_cat
             @test y == expected
-            y = TuringGLM.data_response(f, nt_str)
+            y = T.data_response(f, nt_str)
             @test y == expected
-            y = TuringGLM.data_response(f, nt_cat)
+            y = T.data_response(f, nt_cat)
             @test y == expected
         end
         @testset "DataFrames" begin
             expected = [2, 3, 4, 5]
             f = @formula y_int ~ 0 + x_float + x_cat
-            y = TuringGLM.data_response(f, df_str)
+            y = T.data_response(f, df_str)
             @test y == expected
-            y = TuringGLM.data_response(f, df_cat)
+            y = T.data_response(f, df_cat)
             @test y == expected
             f = @formula y_int ~ 1 + x_float + x_cat
-            y = TuringGLM.data_response(f, df_str)
+            y = T.data_response(f, df_str)
             @test y == expected
-            y = TuringGLM.data_response(f, df_cat)
+            y = T.data_response(f, df_cat)
             @test y == expected
 
             expected = [2.3, 3.4, 4.5, 5.4]
             f = @formula y_float ~ 0 + x_float + x_cat
-            y = TuringGLM.data_response(f, df_str)
+            y = T.data_response(f, df_str)
             @test y == expected
-            y = TuringGLM.data_response(f, df_cat)
+            y = T.data_response(f, df_cat)
             @test y == expected
             f = @formula y_float ~ 1 + x_float + x_cat
-            y = TuringGLM.data_response(f, df_str)
+            y = T.data_response(f, df_str)
             @test y == expected
-            y = TuringGLM.data_response(f, df_cat)
+            y = T.data_response(f, df_cat)
             @test y == expected
         end
     end
@@ -62,35 +62,35 @@
             ]
 
             f = @formula y_int ~ 0 + x_float + x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
+            X = T.data_fixed_effects(f, nt_str)
             @test X == expected
 
             f = @formula y_int ~ 1 + x_float + x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
+            X = T.data_fixed_effects(f, nt_str)
             @test X == expected
 
             f = @formula y_float ~ 0 + x_float + x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
+            X = T.data_fixed_effects(f, nt_str)
             @test X == expected
 
             f = @formula y_float ~ 1 + x_float + x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
+            X = T.data_fixed_effects(f, nt_str)
             @test X == expected
 
             f = @formula y_int ~ 0 + x_float + x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            X = T.data_fixed_effects(f, nt_cat)
             @test X == expected
 
             f = @formula y_int ~ 1 + x_float + x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            X = T.data_fixed_effects(f, nt_cat)
             @test X == expected
 
             f = @formula y_float ~ 0 + x_float + x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            X = T.data_fixed_effects(f, nt_cat)
             @test X == expected
 
             f = @formula y_float ~ 1 + x_float + x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            X = T.data_fixed_effects(f, nt_cat)
             @test X == expected
 
             # Interactions
@@ -102,27 +102,27 @@
             ]
 
             f = @formula y_float ~ 0 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
+            X = T.data_fixed_effects(f, nt_str)
             @test X == expected
 
             f = @formula y_float ~ 1 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
+            X = T.data_fixed_effects(f, nt_str)
             @test X == expected
 
             f = @formula y_float ~ 0 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            X = T.data_fixed_effects(f, nt_cat)
             @test X == expected
 
             f = @formula y_float ~ 1 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            X = T.data_fixed_effects(f, nt_cat)
             @test X == expected
 
             f = @formula y_float ~ 0 + x_int * x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            X = T.data_fixed_effects(f, nt_cat)
             @test X == expected
 
             f = @formula y_float ~ 1 + x_int * x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            X = T.data_fixed_effects(f, nt_cat)
             @test X == expected
 
             # Interactions coming first
@@ -134,7 +134,7 @@
             ]
 
             f = @formula y_float ~ 1 + x_int * x_cat + x_float
-            X = TuringGLM.data_fixed_effects(f, nt_str)
+            X = T.data_fixed_effects(f, nt_str)
             @test X == expected
         end
         @testset "DataFrames" begin
@@ -146,35 +146,35 @@
             ]
 
             f = @formula(y_int ~ 0 + x_float + x_cat)
-            X = TuringGLM.data_fixed_effects(f, df_str)
+            X = T.data_fixed_effects(f, df_str)
             @test X == expected
 
             f = @formula(y_int ~ 1 + x_float + x_cat)
-            X = TuringGLM.data_fixed_effects(f, df_str)
+            X = T.data_fixed_effects(f, df_str)
             @test X == expected
 
             f = @formula(y_float ~ 0 + x_float + x_cat)
-            X = TuringGLM.data_fixed_effects(f, df_str)
+            X = T.data_fixed_effects(f, df_str)
             @test X == expected
 
             f = @formula(y_float ~ 1 + x_float + x_cat)
-            X = TuringGLM.data_fixed_effects(f, df_str)
+            X = T.data_fixed_effects(f, df_str)
             @test X == expected
 
             f = @formula(y_int ~ 0 + x_float + x_cat_ordered)
-            X = TuringGLM.data_fixed_effects(f, df_cat)
+            X = T.data_fixed_effects(f, df_cat)
             @test X == expected
 
             f = @formula(y_int ~ 1 + x_float + x_cat_ordered)
-            X = TuringGLM.data_fixed_effects(f, df_cat)
+            X = T.data_fixed_effects(f, df_cat)
             @test X == expected
 
             f = @formula(y_float ~ 0 + x_float + x_cat_ordered)
-            X = TuringGLM.data_fixed_effects(f, df_cat)
+            X = T.data_fixed_effects(f, df_cat)
             @test X == expected
 
             f = @formula(y_float ~ 1 + x_float + x_cat_ordered)
-            X = TuringGLM.data_fixed_effects(f, df_cat)
+            X = T.data_fixed_effects(f, df_cat)
             @test X == expected
 
             # Interactions
@@ -186,27 +186,27 @@
             ]
 
             f = @formula y_float ~ 0 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, df_str)
+            X = T.data_fixed_effects(f, df_str)
             @test X == expected
 
             f = @formula y_float ~ 1 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, df_str)
+            X = T.data_fixed_effects(f, df_str)
             @test X == expected
 
             f = @formula y_float ~ 0 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, df_cat)
+            X = T.data_fixed_effects(f, df_cat)
             @test X == expected
 
             f = @formula y_float ~ 1 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, df_cat)
+            X = T.data_fixed_effects(f, df_cat)
             @test X == expected
 
             f = @formula y_float ~ 0 + x_int * x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, df_cat)
+            X = T.data_fixed_effects(f, df_cat)
             @test X == expected
 
             f = @formula y_float ~ 1 + x_int * x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, df_cat)
+            X = T.data_fixed_effects(f, df_cat)
             @test X == expected
 
             # Interactions coming first
@@ -218,7 +218,7 @@
             ]
 
             f = @formula y_float ~ 1 + x_int * x_cat + x_float
-            X = TuringGLM.data_fixed_effects(f, df_str)
+            X = T.data_fixed_effects(f, df_str)
             @test X == expected
         end
     end

--- a/test/data_constructors.jl
+++ b/test/data_constructors.jl
@@ -1,63 +1,70 @@
 @testset "data_constructors.jl" begin
     @testset "data_response" begin
         @testset "NamedTuples" begin
+            expected = [2, 3, 4, 5]
             f = @formula y_int ~ 0 + x_float + x_cat
             y = TuringGLM.data_response(f, nt_str)
-            @test y == [2, 3, 4, 5]
+            @test y == expected
             y = TuringGLM.data_response(f, nt_cat)
-            @test y == [2, 3, 4, 5]
+            @test y == expected
             f = @formula y_int ~ 1 + x_float + x_cat
             y = TuringGLM.data_response(f, nt_str)
-            @test y == [2, 3, 4, 5]
+            @test y == expected
             y = TuringGLM.data_response(f, nt_cat)
-            @test y == [2, 3, 4, 5]
+            @test y == expected
 
+            expected = [2.3, 3.4, 4.5, 5.4]
             f = @formula y_float ~ 0 + x_float + x_cat
             y = TuringGLM.data_response(f, nt_str)
-            @test y == [2.3, 3.4, 4.5, 5.4]
+            @test y == expected
             y = TuringGLM.data_response(f, nt_cat)
-            @test y == [2.3, 3.4, 4.5, 5.4]
+            @test y == expected
             f = @formula y_float ~ 1 + x_float + x_cat
+            @test y == expected
             y = TuringGLM.data_response(f, nt_str)
-            @test y == [2.3, 3.4, 4.5, 5.4]
+            @test y == expected
             y = TuringGLM.data_response(f, nt_cat)
-            @test y == [2.3, 3.4, 4.5, 5.4]
+            @test y == expected
         end
         @testset "DataFrames" begin
+            expected = [2, 3, 4, 5]
             f = @formula y_int ~ 0 + x_float + x_cat
             y = TuringGLM.data_response(f, df_str)
-            @test y == [2, 3, 4, 5]
+            @test y == expected
             y = TuringGLM.data_response(f, df_cat)
-            @test y == [2, 3, 4, 5]
+            @test y == expected
             f = @formula y_int ~ 1 + x_float + x_cat
             y = TuringGLM.data_response(f, df_str)
-            @test y == [2, 3, 4, 5]
+            @test y == expected
             y = TuringGLM.data_response(f, df_cat)
-            @test y == [2, 3, 4, 5]
+            @test y == expected
 
+            expected = [2.3, 3.4, 4.5, 5.4]
             f = @formula y_float ~ 0 + x_float + x_cat
             y = TuringGLM.data_response(f, df_str)
-            @test y == [2.3, 3.4, 4.5, 5.4]
+            @test y == expected
             y = TuringGLM.data_response(f, df_cat)
-            @test y == [2.3, 3.4, 4.5, 5.4]
+            @test y == expected
             f = @formula y_float ~ 1 + x_float + x_cat
             y = TuringGLM.data_response(f, df_str)
-            @test y == [2.3, 3.4, 4.5, 5.4]
+            @test y == expected
             y = TuringGLM.data_response(f, df_cat)
-            @test y == [2.3, 3.4, 4.5, 5.4]
+            @test y == expected
         end
     end
     @testset "data_fixed_effects" begin
         @testset "NamedTuples" begin
-            f = @formula y_int ~ 0 + x_float + x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
             expected = [
                 1.1 0.0 0.0 0.0
                 2.3 1.0 0.0 0.0
                 3.14 0.0 1.0 0.0
                 3.65 0.0 0.0 1.0
             ]
+
+            f = @formula y_int ~ 0 + x_float + x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_str)
             @test X == expected
+
             f = @formula y_int ~ 1 + x_float + x_cat
             X = TuringGLM.data_fixed_effects(f, nt_str)
             @test X == expected
@@ -65,233 +72,154 @@
             f = @formula y_float ~ 0 + x_float + x_cat
             X = TuringGLM.data_fixed_effects(f, nt_str)
             @test X == expected
-            
+
             f = @formula y_float ~ 1 + x_float + x_cat
             X = TuringGLM.data_fixed_effects(f, nt_str)
             @test X == expected
 
             f = @formula y_int ~ 0 + x_float + x_cat_ordered
             X = TuringGLM.data_fixed_effects(f, nt_cat)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
+
             f = @formula y_int ~ 1 + x_float + x_cat_ordered
             X = TuringGLM.data_fixed_effects(f, nt_cat)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
 
             f = @formula y_float ~ 0 + x_float + x_cat_ordered
             X = TuringGLM.data_fixed_effects(f, nt_cat)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
+
             f = @formula y_float ~ 1 + x_float + x_cat_ordered
             X = TuringGLM.data_fixed_effects(f, nt_cat)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
 
             # Interactions
-            f = @formula y_float ~ 0 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 1 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_str)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 0 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 1 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 0 + x_int * x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 1 + x_int * x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, nt_cat)
-            @test X == [
+            expected = [
                 1.0 0.0 0.0 0.0 0.0 0.0 0.0
                 2.0 1.0 0.0 0.0 2.0 0.0 0.0
                 3.0 0.0 1.0 0.0 0.0 3.0 0.0
                 4.0 0.0 0.0 1.0 0.0 0.0 4.0
             ]
 
-            # Interactions coming first
-            f = @formula y_float ~ 1 + x_int * x_cat + x_float
+            f = @formula y_float ~ 0 + x_int * x_cat
             X = TuringGLM.data_fixed_effects(f, nt_str)
-            @test X == [
+            @test X == expected
+
+            f = @formula y_float ~ 1 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == expected
+
+            f = @formula y_float ~ 0 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == expected
+
+            f = @formula y_float ~ 1 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == expected
+
+            f = @formula y_float ~ 0 + x_int * x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == expected
+
+            f = @formula y_float ~ 1 + x_int * x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == expected
+
+            # Interactions coming first
+            expected = [
                 1.0 0.0 0.0 0.0 1.1 0.0 0.0 0.0
                 2.0 1.0 0.0 0.0 2.3 2.0 0.0 0.0
                 3.0 0.0 1.0 0.0 3.14 0.0 3.0 0.0
                 4.0 0.0 0.0 1.0 3.65 0.0 0.0 4.0
             ]
+
+            f = @formula y_float ~ 1 + x_int * x_cat + x_float
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == expected
         end
         @testset "DataFrames" begin
+            expected = [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+
             f = @formula(y_int ~ 0 + x_float + x_cat)
             X = TuringGLM.data_fixed_effects(f, df_str)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
+
             f = @formula(y_int ~ 1 + x_float + x_cat)
             X = TuringGLM.data_fixed_effects(f, df_str)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
 
             f = @formula(y_float ~ 0 + x_float + x_cat)
             X = TuringGLM.data_fixed_effects(f, df_str)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
+
             f = @formula(y_float ~ 1 + x_float + x_cat)
             X = TuringGLM.data_fixed_effects(f, df_str)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
 
             f = @formula(y_int ~ 0 + x_float + x_cat_ordered)
             X = TuringGLM.data_fixed_effects(f, df_cat)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
+
             f = @formula(y_int ~ 1 + x_float + x_cat_ordered)
             X = TuringGLM.data_fixed_effects(f, df_cat)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
 
             f = @formula(y_float ~ 0 + x_float + x_cat_ordered)
             X = TuringGLM.data_fixed_effects(f, df_cat)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
+
             f = @formula(y_float ~ 1 + x_float + x_cat_ordered)
             X = TuringGLM.data_fixed_effects(f, df_cat)
-            @test X == [
-                1.1 0.0 0.0 0.0
-                2.3 1.0 0.0 0.0
-                3.14 0.0 1.0 0.0
-                3.65 0.0 0.0 1.0
-            ]
+            @test X == expected
 
             # Interactions
-            f = @formula y_float ~ 0 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, df_str)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 1 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, df_str)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 0 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, df_cat)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 1 + x_int * x_cat
-            X = TuringGLM.data_fixed_effects(f, df_cat)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 0 + x_int * x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, df_cat)
-            @test X == [
-                1.0 0.0 0.0 0.0 0.0 0.0 0.0
-                2.0 1.0 0.0 0.0 2.0 0.0 0.0
-                3.0 0.0 1.0 0.0 0.0 3.0 0.0
-                4.0 0.0 0.0 1.0 0.0 0.0 4.0
-            ]
-            f = @formula y_float ~ 1 + x_int * x_cat_ordered
-            X = TuringGLM.data_fixed_effects(f, df_cat)
-            @test X == [
+            expected = [
                 1.0 0.0 0.0 0.0 0.0 0.0 0.0
                 2.0 1.0 0.0 0.0 2.0 0.0 0.0
                 3.0 0.0 1.0 0.0 0.0 3.0 0.0
                 4.0 0.0 0.0 1.0 0.0 0.0 4.0
             ]
 
-            # Interactions coming first
-            f = @formula y_float ~ 1 + x_int * x_cat + x_float
+            f = @formula y_float ~ 0 + x_int * x_cat
             X = TuringGLM.data_fixed_effects(f, df_str)
-            @test X == [
+            @test X == expected
+
+            f = @formula y_float ~ 1 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == expected
+
+            f = @formula y_float ~ 0 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == expected
+
+            f = @formula y_float ~ 1 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == expected
+
+            f = @formula y_float ~ 0 + x_int * x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == expected
+
+            f = @formula y_float ~ 1 + x_int * x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == expected
+
+            # Interactions coming first
+            expected = [
                 1.0 0.0 0.0 0.0 1.1 0.0 0.0 0.0
                 2.0 1.0 0.0 0.0 2.3 2.0 0.0 0.0
                 3.0 0.0 1.0 0.0 3.14 0.0 3.0 0.0
                 4.0 0.0 0.0 1.0 3.65 0.0 0.0 4.0
             ]
+
+            f = @formula y_float ~ 1 + x_int * x_cat + x_float
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == expected
         end
     end
     @testset "data_random_effects" begin end

--- a/test/data_constructors.jl
+++ b/test/data_constructors.jl
@@ -1,105 +1,311 @@
 @testset "data_constructors.jl" begin
     @testset "data_response" begin
-        # NamedTuples
-        f = @formula(y_int ~ x_float + x_cat)
-        y = TuringGLM.data_response(f, nt_str)
-        @test y == [2, 3, 4, 5]
-        y = TuringGLM.data_response(f, nt_cat)
-        @test y == [2, 3, 4, 5]
+        @testset "NamedTuples" begin
+            f = @formula y_int ~ 0 + x_float + x_cat
+            y = TuringGLM.data_response(f, nt_str)
+            @test y == [2, 3, 4, 5]
+            y = TuringGLM.data_response(f, nt_cat)
+            @test y == [2, 3, 4, 5]
+            f = @formula y_int ~ 1 + x_float + x_cat
+            y = TuringGLM.data_response(f, nt_str)
+            @test y == [2, 3, 4, 5]
+            y = TuringGLM.data_response(f, nt_cat)
+            @test y == [2, 3, 4, 5]
 
-        f = @formula(y_float ~ x_float + x_cat)
-        y = TuringGLM.data_response(f, nt_str)
-        @test y == [2.3, 3.4, 4.5, 5.4]
-        y = TuringGLM.data_response(f, nt_cat)
-        @test y == [2.3, 3.4, 4.5, 5.4]
+            f = @formula y_float ~ 0 + x_float + x_cat
+            y = TuringGLM.data_response(f, nt_str)
+            @test y == [2.3, 3.4, 4.5, 5.4]
+            y = TuringGLM.data_response(f, nt_cat)
+            @test y == [2.3, 3.4, 4.5, 5.4]
+            f = @formula y_float ~ 1 + x_float + x_cat
+            y = TuringGLM.data_response(f, nt_str)
+            @test y == [2.3, 3.4, 4.5, 5.4]
+            y = TuringGLM.data_response(f, nt_cat)
+            @test y == [2.3, 3.4, 4.5, 5.4]
+        end
+        @testset "DataFrames" begin
+            f = @formula y_int ~ 0 + x_float + x_cat
+            y = TuringGLM.data_response(f, df_str)
+            @test y == [2, 3, 4, 5]
+            y = TuringGLM.data_response(f, df_cat)
+            @test y == [2, 3, 4, 5]
+            f = @formula y_int ~ 1 + x_float + x_cat
+            y = TuringGLM.data_response(f, df_str)
+            @test y == [2, 3, 4, 5]
+            y = TuringGLM.data_response(f, df_cat)
+            @test y == [2, 3, 4, 5]
 
-        # DataFrames
-        f = @formula(y_int ~ x_float + x_cat)
-        y = TuringGLM.data_response(f, df_str)
-        @test y == [2, 3, 4, 5]
-        y = TuringGLM.data_response(f, df_cat)
-        @test y == [2, 3, 4, 5]
-
-        f = @formula(y_float ~ x_float + x_cat)
-        y = TuringGLM.data_response(f, df_str)
-        @test y == [2.3, 3.4, 4.5, 5.4]
-        y = TuringGLM.data_response(f, df_cat)
-        @test y == [2.3, 3.4, 4.5, 5.4]
+            f = @formula y_float ~ 0 + x_float + x_cat
+            y = TuringGLM.data_response(f, df_str)
+            @test y == [2.3, 3.4, 4.5, 5.4]
+            y = TuringGLM.data_response(f, df_cat)
+            @test y == [2.3, 3.4, 4.5, 5.4]
+            f = @formula y_float ~ 1 + x_float + x_cat
+            y = TuringGLM.data_response(f, df_str)
+            @test y == [2.3, 3.4, 4.5, 5.4]
+            y = TuringGLM.data_response(f, df_cat)
+            @test y == [2.3, 3.4, 4.5, 5.4]
+        end
     end
     @testset "data_fixed_effects" begin
-        # NamedTuples
-        f = @formula(y_int ~ x_float + x_cat)
-        m = TuringGLM.data_fixed_effects(f, nt_str)
-        @test X == [
-            1.1 0.0 0.0 0.0
-            2.3 1.0 0.0 0.0
-            3.14 0.0 1.0 0.0
-            3.65 0.0 0.0 1.0
-        ]
+        @testset "NamedTuples" begin
+            f = @formula y_int ~ 0 + x_float + x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+            f = @formula y_int ~ 1 + x_float + x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
 
-        f = @formula(y_float ~ x_float + x_cat)
-        m = TuringGLM.data_fixed_effects(f, nt_str)
-        @test X == [
-            1.1 0.0 0.0 0.0
-            2.3 1.0 0.0 0.0
-            3.14 0.0 1.0 0.0
-            3.65 0.0 0.0 1.0
-        ]
+            f = @formula y_float ~ 0 + x_float + x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+            f = @formula y_float ~ 1 + x_float + x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
 
-        f = @formula(y_int ~ x_float + x_cat_ordered)
-        m = TuringGLM.data_fixed_effects(f, nt_cat)
-        @test X == [
-            1.1 0.0 0.0 0.0
-            2.3 1.0 0.0 0.0
-            3.14 0.0 1.0 0.0
-            3.65 0.0 0.0 1.0
-        ]
+            f = @formula y_int ~ 0 + x_float + x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+            f = @formula y_int ~ 1 + x_float + x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
 
-        f = @formula(y_float ~ x_float + x_cat_ordered)
-        m = TuringGLM.data_fixed_effects(f, nt_cat)
-        @test X == [
-            1.1 0.0 0.0 0.0
-            2.3 1.0 0.0 0.0
-            3.14 0.0 1.0 0.0
-            3.65 0.0 0.0 1.0
-        ]
+            f = @formula y_float ~ 0 + x_float + x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+            f = @formula y_float ~ 1 + x_float + x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
 
-        # DataFrames
-        f = @formula(y_int ~ x_float + x_cat)
-        m = TuringGLM.data_fixed_effects(f, df_str)
-        @test X == [
-            1.1 0.0 0.0 0.0
-            2.3 1.0 0.0 0.0
-            3.14 0.0 1.0 0.0
-            3.65 0.0 0.0 1.0
-        ]
+            # Interactions
+            f = @formula y_float ~ 0 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 1 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 0 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 1 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 0 + x_int * x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 1 + x_int * x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, nt_cat)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
 
-        f = @formula(y_float ~ x_float + x_cat)
-        m = TuringGLM.data_fixed_effects(f, df_str)
-        @test X == [
-            1.1 0.0 0.0 0.0
-            2.3 1.0 0.0 0.0
-            3.14 0.0 1.0 0.0
-            3.65 0.0 0.0 1.0
-        ]
+            # Interactions coming first
+            f = @formula y_float ~ 1 + x_int * x_cat + x_float
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            @test X == [
+                1.0 0.0 0.0 0.0 1.1 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.3 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 3.14 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 3.65 0.0 0.0 4.0
+            ]
+        end
+        @testset "DataFrames" begin
+            f = @formula(y_int ~ 0 + x_float + x_cat)
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+            f = @formula(y_int ~ 1 + x_float + x_cat)
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
 
-        f = @formula(y_int ~ x_float + x_cat_ordered)
-        m = TuringGLM.data_fixed_effects(f, df_cat)
-        @test X == [
-            1.1 0.0 0.0 0.0
-            2.3 1.0 0.0 0.0
-            3.14 0.0 1.0 0.0
-            3.65 0.0 0.0 1.0
-        ]
+            f = @formula(y_float ~ 0 + x_float + x_cat)
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+            f = @formula(y_float ~ 1 + x_float + x_cat)
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
 
-        f = @formula(y_float ~ x_float + x_cat_ordered)
-        m = TuringGLM.data_fixed_effects(f, df_cat)
-        @test X == [
-            1.1 0.0 0.0 0.0
-            2.3 1.0 0.0 0.0
-            3.14 0.0 1.0 0.0
-            3.65 0.0 0.0 1.0
-        ]
+            f = @formula(y_int ~ 0 + x_float + x_cat_ordered)
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+            f = @formula(y_int ~ 1 + x_float + x_cat_ordered)
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+
+            f = @formula(y_float ~ 0 + x_float + x_cat_ordered)
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+            f = @formula(y_float ~ 1 + x_float + x_cat_ordered)
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == [
+                1.1 0.0 0.0 0.0
+                2.3 1.0 0.0 0.0
+                3.14 0.0 1.0 0.0
+                3.65 0.0 0.0 1.0
+            ]
+
+            # Interactions
+            f = @formula y_float ~ 0 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 1 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 0 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 1 + x_int * x_cat
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 0 + x_int * x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+            f = @formula y_float ~ 1 + x_int * x_cat_ordered
+            X = TuringGLM.data_fixed_effects(f, df_cat)
+            @test X == [
+                1.0 0.0 0.0 0.0 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 0.0 0.0 4.0
+            ]
+
+            # Interactions coming first
+            f = @formula y_float ~ 1 + x_int * x_cat + x_float
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            @test X == [
+                1.0 0.0 0.0 0.0 1.1 0.0 0.0 0.0
+                2.0 1.0 0.0 0.0 2.3 2.0 0.0 0.0
+                3.0 0.0 1.0 0.0 3.14 0.0 3.0 0.0
+                4.0 0.0 0.0 1.0 3.65 0.0 0.0 4.0
+            ]
+        end
     end
     @testset "data_random_effects" begin end
 end

--- a/test/error_messages.jl
+++ b/test/error_messages.jl
@@ -1,16 +1,14 @@
 @testset "error_messages" begin
-    using TuringGLM: concrete_term, schema
-    using TuringGLM: Term
     d = (yyy=rand(10), aaa=rand(10), bbb=repeat([:a, :b], 5))
     @test_throws ArgumentError(
         "There isn't a variable called 'aa' in your data; the nearest names appear to be: aaa",
-    ) concrete_term(Term(:aa), d, nothing)
+    ) T.concrete_term(T.Term(:aa), d, nothing)
     @test_throws ArgumentError(
         "There isn't a variable called 'aab' in your data; the nearest names appear to be: aaa, bbb",
-    ) concrete_term(Term(:aab), d, nothing)
+    ) T.concrete_term(T.Term(:aab), d, nothing)
 
-    @test_throws ArgumentError("Column 'a' is empty.") concrete_term(
-        Term(:a), (; a=[]), nothing
+    @test_throws ArgumentError("Column 'a' is empty.") T.concrete_term(
+        T.Term(:a), (; a=[]), nothing
     )
-    @test_throws ArgumentError("Column 'a' is empty.") schema((; b=[1, 2], a=[]))
+    @test_throws ArgumentError("Column 'a' is empty.") T.schema((; b=[1, 2], a=[]))
 end

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -1,88 +1,85 @@
 @testset "formula" begin
-    using TuringGLM: ConstantTerm
-    using TuringGLM: hasresponse, hasintercept, omitsintercept, term, terms, drop_term
-
-    y, x1, x2, x3, a, b, c, onet = term.((:y, :x1, :x2, :x3, :a, :b, :c, 1))
+    y, x1, x2, x3, a, b, c, onet = T.term.((:y, :x1, :x2, :x3, :a, :b, :c, 1))
 
     @testset "terms" begin
 
         # totally empty
         f = @formula(0 ~ 0)
-        @test !hasresponse(f)
-        @test !hasintercept(f)
-        @test omitsintercept(f)
-        @test f.rhs == ConstantTerm(0)
-        @test issetequal(terms(f), [ConstantTerm(0)])
+        @test !T.hasresponse(f)
+        @test !T.hasintercept(f)
+        @test T.omitsintercept(f)
+        @test f.rhs == T.ConstantTerm(0)
+        @test issetequal(T.terms(f), [T.ConstantTerm(0)])
 
         # empty lhs, intercept on rhs
         f = @formula(0 ~ 1)
-        @test !hasresponse(f)
-        @test hasintercept(f)
-        @test !omitsintercept(f)
+        @test !T.hasresponse(f)
+        @test T.hasintercept(f)
+        @test !T.omitsintercept(f)
 
         # empty RHS
         f = @formula(y ~ 0)
-        @test hasintercept(f) == false
-        @test omitsintercept(f) == true
-        @test hasresponse(f)
-        @test f.rhs == ConstantTerm(0)
-        @test issetequal(terms(f), term.((:y, 0)))
+        @test T.hasintercept(f) == false
+        @test T.omitsintercept(f) == true
+        @test T.hasresponse(f)
+        @test f.rhs == T.ConstantTerm(0)
+        @test issetequal(T.terms(f), T.term.((:y, 0)))
 
         f = @formula(y ~ -1)
-        @test hasintercept(f) == false
-        @test omitsintercept(f) == true
+        @test T.hasintercept(f) == false
+        @test T.omitsintercept(f) == true
 
         # intercept-only
         f = @formula(y ~ 1)
-        @test hasresponse(f) == true
-        @test hasintercept(f) == true
+        @test T.hasresponse(f) == true
+        @test T.hasintercept(f) == true
         @test f.rhs == onet
-        @test issetequal(terms(f), (onet, y))
+        @test issetequal(T.terms(f), (onet, y))
 
         # simple formula
         f = @formula y ~ 1 + x1
-        @test hasresponse(f) == true
-        @test hasintercept(f) == true
+        @test T.hasresponse(f) == true
+        @test T.hasintercept(f) == true
 
         # terms add
         f = @formula y ~ 1 + x1 + x2
-        @test hasresponse(f) == true
+        @test T.hasresponse(f) == true
         @test f.rhs == (onet, x1, x2)
-        @test issetequal(terms(f), [y, onet, x1, x2])
+        @test issetequal(T.terms(f), [y, onet, x1, x2])
 
         # implicit intercept behavior: NO intercept after @formula
         f = @formula(y ~ x1 + x2)
-        @test hasintercept(f) == false
-        @test omitsintercept(f) == false
+        @test T.hasintercept(f) == false
+        @test T.omitsintercept(f) == false
         @test f.rhs == (x1, x2)
-        @test issetequal(terms(f), [y, x1, x2])
+        @test issetequal(T.terms(f), [y, x1, x2])
 
         # no intercept
         f = @formula(y ~ 0 + x1 + x2)
-        @test hasintercept(f) == false
-        @test omitsintercept(f) == true
-        @test f.rhs == term.((0, :x1, :x2))
+        @test T.hasintercept(f) == false
+        @test T.omitsintercept(f) == true
+        @test f.rhs == T.term.((0, :x1, :x2))
 
         f = @formula(y ~ -1 + x1 + x2)
-        @test hasintercept(f) == false
-        @test omitsintercept(f) == true
-        @test f.rhs == term.((-1, :x1, :x2))
+        @test T.hasintercept(f) == false
+        @test T.omitsintercept(f) == true
+        @test f.rhs == T.term.((-1, :x1, :x2))
 
         f = @formula(y ~ x1 & x2)
-        @test hasintercept(f) == false
-        @test omitsintercept(f) == false
+        @test T.hasintercept(f) == false
+        @test T.omitsintercept(f) == false
         @test f.rhs == x1 & x2
-        @test issetequal(terms(f), [y, x1, x2])
+        @test issetequal(T.terms(f), [y, x1, x2])
 
         # plain interaction
         f = @formula y ~ x1 & x2
         @test f.rhs == x1 & x2
-        @test issetequal(terms(f), [y, x1, x2])
+        @test issetequal(T.terms(f), [y, x1, x2])
 
         # `*` main effects and interactions expansion
         f = @formula(y ~ x1 * x2)
         @test f.rhs == (x1, x2, x1 & x2)
-        @test issetequal(terms(f), [y, x1, x2])
+        @test issetequal(T.terms(f), [y, x1, x2])
 
         # Incorrect formula separator
         @test_throws LoadError @eval @formula(y => x1 + x2)
@@ -96,12 +93,12 @@
         # `&`
         f = @formula(y ~ x1 & x2 & x3)
         @test f.rhs == x1 & x2 & x3
-        @test issetequal(terms(f), [y, x1, x2, x3])
+        @test issetequal(T.terms(f), [y, x1, x2, x3])
 
         # distributive property of `+` and `&`
         f = @formula(y ~ x1 & (x2 + x3))
         @test f.rhs == (x1 & x2, x1 & x3)
-        @test issetequal(terms(f), [y, x1, x2, x3])
+        @test issetequal(T.terms(f), [y, x1, x2, x3])
 
         # ordering of interaction terms is preserved across distributive
         f = @formula(y ~ (x2 + x3) & x1)
@@ -114,7 +111,7 @@
         # three-way `*`
         f = @formula(y ~ a * b * c)
         @test f.rhs == (a, b, c, a & b, a & c, b & c, a & b & c)
-        @test issetequal(terms(f), (y, a, b, c))
+        @test issetequal(T.terms(f), (y, a, b, c))
 
         # Interactions with `1` reduce to main effect.
         f = @formula(y ~ 1 & x1)
@@ -127,7 +124,7 @@
     @testset "drop_terms" begin
         form = @formula(foo ~ 1 + bar + baz)
         @test form == @formula(foo ~ 1 + bar + baz)
-        drop_term(form, term(:bar))
+        T.drop_term(form, T.term(:bar))
         # drop_term creates a new formula:
         @test form != @formula(foo ~ 1 + baz)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,11 +25,11 @@ df_str = DataFrame(nt_str)
 df_cat = DataFrame(nt_cat)
 
 @testset "TuringGLM.jl" begin
-    # include("utils.jl")
     include("formula.jl")
     include("terms.jl")
     include("schema.jl")
     include("error_messages.jl")
-    # include("contrasts.jl")
-    # include("data_constructors.jl")
+    include("contrasts.jl")
+    include("data_constructors.jl")
+    include("utils.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using DataFrames
 using CategoricalArrays: categorical
 using Statistics: mean, std
 
+const T = TuringGLM
+
 x_float = [1.1, 2.3, 3.14, 3.65]
 x_int = [1, 2, 3, 4]
 y_float = [2.3, 3.4, 4.5, 5.4]

--- a/test/schema.jl
+++ b/test/schema.jl
@@ -1,44 +1,41 @@
 @testset "schema" begin
-    using TuringGLM:
-        apply_schema, collect_matrix_terms, concrete_term, has_schema, schema, term
-    using TuringGLM: CategoricalTerm, ConstantTerm, DummyCoding, Term, FullRank
-
     @testset "no-op apply_schema" begin
         f = @formula(y ~ 1 + a + b + c + b & c)
         df = (y=rand(9), a=1:9, b=rand(9), c=repeat(["d", "e", "f"], 3))
-        f = apply_schema(f, schema(f, df))
-        @test f == apply_schema(f, schema(f, df))
+        f = T.apply_schema(f, T.schema(f, df))
+        @test f == T.apply_schema(f, T.schema(f, df))
     end
 
     @testset "lonely term in a tuple" begin
         d = (a=[1, 1],)
-        @test apply_schema(ConstantTerm(1), schema(d)) ==
-            apply_schema((ConstantTerm(1),), schema(d))
-        @test apply_schema(Term(:a), schema(d)) == apply_schema((Term(:a),), schema(d))
+        @test T.apply_schema(T.ConstantTerm(1), T.schema(d)) ==
+            T.apply_schema((T.ConstantTerm(1),), T.schema(d))
+        @test T.apply_schema(T.Term(:a), T.schema(d)) ==
+            T.apply_schema((T.Term(:a),), T.schema(d))
     end
 
     @testset "hints" begin
         f = @formula(y ~ 1 + a)
         d = (y=rand(10), a=repeat([1, 2]; outer=2))
 
-        sch = schema(f, d)
-        @test sch[term(:a)] isa ContinuousTerm
+        sch = T.schema(f, d)
+        @test sch[T.term(:a)] isa T.ContinuousTerm
 
-        sch1 = schema(f, d, Dict(:a => CategoricalTerm))
-        @test sch1[term(:a)] isa CategoricalTerm{DummyCoding}
-        f1 = apply_schema(f, sch1)
-        @test f1.rhs.terms[end] == sch1[term(:a)]
+        sch1 = T.schema(f, d, Dict(:a => T.CategoricalTerm))
+        @test sch1[T.term(:a)] isa T.CategoricalTerm{T.DummyCoding}
+        f1 = T.apply_schema(f, sch1)
+        @test f1.rhs.terms[end] == sch1[T.term(:a)]
 
-        sch2 = schema(f, d, Dict(:a => DummyCoding()))
-        @test sch2[term(:a)] isa CategoricalTerm{DummyCoding}
-        f2 = apply_schema(f, sch2)
-        @test f2.rhs.terms[end] == sch2[term(:a)]
+        sch2 = T.schema(f, d, Dict(:a => T.DummyCoding()))
+        @test sch2[T.term(:a)] isa T.CategoricalTerm{T.DummyCoding}
+        f2 = T.apply_schema(f, sch2)
+        @test f2.rhs.terms[end] == sch2[T.term(:a)]
 
-        hint = deepcopy(sch2[term(:a)])
-        sch3 = schema(f, d, Dict(:a => hint))
+        hint = deepcopy(sch2[T.term(:a)])
+        sch3 = T.schema(f, d, Dict(:a => hint))
         # if an <:AbstractTerm is supplied as hint, it's included as is
-        @test sch3[term(:a)] === hint !== sch2[term(:a)]
-        f3 = apply_schema(f, sch3)
+        @test sch3[T.term(:a)] === hint !== sch2[T.term(:a)]
+        f3 = T.apply_schema(f, sch3)
         @test f3.rhs.terms[end] === hint
     end
 
@@ -46,25 +43,25 @@
         d = (y=rand(10), a=rand(10), b=repeat([:a, :b], 5))
 
         f = @formula(y ~ a * b)
-        @test !has_schema(f)
-        @test !has_schema(f.rhs)
-        @test !has_schema(collect_matrix_terms(f.rhs))
+        @test !T.has_schema(f)
+        @test !T.has_schema(f.rhs)
+        @test !T.has_schema(T.collect_matrix_terms(f.rhs))
 
-        ff = apply_schema(f, schema(d))
-        @test has_schema(ff)
-        @test has_schema(ff.rhs)
-        @test has_schema(collect_matrix_terms(ff.rhs))
+        ff = T.apply_schema(f, T.schema(d))
+        @test T.has_schema(ff)
+        @test T.has_schema(ff.rhs)
+        @test T.has_schema(T.collect_matrix_terms(ff.rhs))
 
-        sch = schema(d)
-        a, b = term.((:a, :b))
-        @test !has_schema(a)
-        @test has_schema(sch[a])
-        @test !has_schema(b)
-        @test has_schema(sch[b])
+        sch = T.schema(d)
+        a, b = T.term.((:a, :b))
+        @test !T.has_schema(a)
+        @test T.has_schema(sch[a])
+        @test !T.has_schema(b)
+        @test T.has_schema(sch[b])
 
-        @test !has_schema(a & b)
-        @test !has_schema(a & sch[b])
-        @test !has_schema(sch[a] & a)
-        @test has_schema(sch[a] & sch[b])
+        @test !T.has_schema(a & b)
+        @test !T.has_schema(a & sch[b])
+        @test !T.has_schema(sch[a] & a)
+        @test T.has_schema(sch[a] & sch[b])
     end
 end

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -6,34 +6,14 @@ end
 mimestring(x) = mimestring(MIME"text/plain", x)
 
 @testset "terms" begin
-    using TuringGLM:
-        apply_schema,
-        coefnames,
-        collect_matrix_terms,
-        concrete_term,
-        hasresponse,
-        hasintercept,
-        omitsintercept,
-        schema,
-        term
-    using TuringGLM: ContrastsMatrix, DummyCoding, FullDummyCoding
-    using TuringGLM:
-        ContinuousTerm,
-        FormulaTerm,
-        InteractionTerm,
-        InterceptTerm,
-        TermOrTerms,
-        TupleTerm,
-        Term
-
     @testset "concrete_term" begin
-        t = term(:aaa)
-        ts = term("aaa")
+        t = T.term(:aaa)
+        ts = T.term("aaa")
         @test t == ts
         @test string(t) == "aaa"
         @test mimestring(t) == "aaa(unknown)"
 
-        t0 = concrete_term(t, [3, 2, 1])
+        t0 = T.concrete_term(t, [3, 2, 1])
         @test string(t0) == "aaa"
         @test mimestring(t0) == "aaa(continuous)"
         @test t0.mean == 2.0
@@ -41,43 +21,43 @@ mimestring(x) = mimestring(MIME"text/plain", x)
         @test t0.min == 1.0
         @test t0.max == 3.0
 
-        t1 = concrete_term(t, [:a, :b, :c])
-        @test t1.contrasts isa ContrastsMatrix{DummyCoding}
+        t1 = T.concrete_term(t, [:a, :b, :c])
+        @test t1.contrasts isa T.ContrastsMatrix{T.DummyCoding}
         @test string(t1) == "aaa"
-        @test mimestring(t1) == "aaa(DummyCoding:3→2)"
+        @test mimestring(t1) == "aaa(TuringGLM.DummyCoding:3→2)"
 
-        t3 = concrete_term(t, [:a, :b, :c], DummyCoding())
-        @test t3.contrasts isa ContrastsMatrix{DummyCoding}
+        t3 = T.concrete_term(t, [:a, :b, :c], T.DummyCoding())
+        @test t3.contrasts isa T.ContrastsMatrix{T.DummyCoding}
         @test string(t3) == "aaa"
-        @test mimestring(t3) == "aaa(DummyCoding:3→2)"
+        @test mimestring(t3) == "aaa(TuringGLM.DummyCoding:3→2)"
 
-        t2full = concrete_term(t, [:a, :a, :b], FullDummyCoding())
-        @test t2full.contrasts isa ContrastsMatrix{FullDummyCoding}
-        @test mimestring(t2full) == "aaa(FullDummyCoding:2→2)"
+        t2full = T.concrete_term(t, [:a, :a, :b], T.FullDummyCoding())
+        @test t2full.contrasts isa T.ContrastsMatrix{T.FullDummyCoding}
+        @test mimestring(t2full) == "aaa(TuringGLM.FullDummyCoding:2→2)"
         @test string(t2full) == "aaa"
     end
 
     @testset "term operators" begin
-        a = term(:a)
-        b = term(:b)
+        a = T.term(:a)
+        b = T.term(:b)
         @test a + b == (a, b)
-        @test (a ~ b) == FormulaTerm(a, b)
+        @test (a ~ b) == T.FormulaTerm(a, b)
         @test string(a ~ b) == "$a ~ $b"
         @test mimestring(a ~ b) == """FormulaTerm
                                       Response:
                                         a(unknown)
                                       Predictors:
                                         b(unknown)"""
-        @test mimestring(a ~ term(1) + b) == """FormulaTerm
+        @test mimestring(a ~ T.term(1) + b) == """FormulaTerm
                                                 Response:
                                                   a(unknown)
                                                 Predictors:
                                                   1
                                                   b(unknown)"""
-        @test a & b == InteractionTerm((a, b))
+        @test a & b == T.InteractionTerm((a, b))
         @test string(a & b) == "$a & $b"
         @test mimestring(a & b) == "a(unknown) & b(unknown)"
-        c = term(:c)
+        c = T.term(:c)
         ab = a + b
         bc = b + c
         abc = a + b + c
@@ -93,93 +73,93 @@ mimestring(x) = mimestring(MIME"text/plain", x)
     end
 
     @testset "expand nested tuples of terms during apply_schema" begin
-        sch = schema((a=rand(10), b=rand(10), c=rand(10)))
+        sch = T.schema((a=rand(10), b=rand(10), c=rand(10)))
 
-        # nested tuples of terms are expanded by apply_schema
-        terms = (term(:a), (term(:b), term(:c)))
-        terms2 = apply_schema(terms, sch)
-        @test terms2 isa NTuple{3,ContinuousTerm}
-        @test terms2 == apply_schema(term.((:a, :b, :c)), sch)
+        # nested tuples of terms are expanded by T.apply_schema
+        terms = (T.term(:a), (T.term(:b), T.term(:c)))
+        terms2 = T.apply_schema(terms, sch)
+        @test terms2 isa NTuple{3,T.ContinuousTerm}
+        @test terms2 == T.apply_schema(T.term.((:a, :b, :c)), sch)
     end
 
     @testset "Intercept and response traits" begin
         has_responses = [
-            term(:y),
-            term(1),
-            InterceptTerm{true}(),
-            term(:y) + term(:z),
-            term(:y) + term(0),
-            term(:y) + InterceptTerm{false}(),
+            T.term(:y),
+            T.term(1),
+            T.InterceptTerm{true}(),
+            T.term(:y) + T.term(:z),
+            T.term(:y) + T.term(0),
+            T.term(:y) + T.InterceptTerm{false}(),
         ]
-        no_responses = [term(0), InterceptTerm{false}()]
+        no_responses = [T.term(0), T.InterceptTerm{false}()]
 
-        has_intercepts = [term(1), InterceptTerm{true}()]
-        omits_intercepts = [term(0), term(-1), InterceptTerm{false}()]
+        has_intercepts = [T.term(1), T.InterceptTerm{true}()]
+        omits_intercepts = [T.term(0), T.term(-1), T.InterceptTerm{false}()]
 
-        a = term(:a)
+        a = T.term(:a)
 
         for lhs in has_responses, rhs in has_intercepts
-            @test hasresponse(lhs ~ rhs)
-            @test hasintercept(lhs ~ rhs)
-            @test !omitsintercept(lhs ~ rhs)
+            @test T.hasresponse(lhs ~ rhs)
+            @test T.hasintercept(lhs ~ rhs)
+            @test !T.omitsintercept(lhs ~ rhs)
 
-            @test hasresponse(lhs ~ rhs + a)
-            @test hasintercept(lhs ~ rhs + a)
-            @test !omitsintercept(lhs ~ rhs + a)
+            @test T.hasresponse(lhs ~ rhs + a)
+            @test T.hasintercept(lhs ~ rhs + a)
+            @test !T.omitsintercept(lhs ~ rhs + a)
         end
 
         for lhs in no_responses, rhs in has_intercepts
-            @test !hasresponse(lhs ~ rhs)
-            @test hasintercept(lhs ~ rhs)
-            @test !omitsintercept(lhs ~ rhs)
+            @test !T.hasresponse(lhs ~ rhs)
+            @test T.hasintercept(lhs ~ rhs)
+            @test !T.omitsintercept(lhs ~ rhs)
 
-            @test !hasresponse(lhs ~ rhs + a)
-            @test hasintercept(lhs ~ rhs + a)
-            @test !omitsintercept(lhs ~ rhs + a)
+            @test !T.hasresponse(lhs ~ rhs + a)
+            @test T.hasintercept(lhs ~ rhs + a)
+            @test !T.omitsintercept(lhs ~ rhs + a)
         end
 
         for lhs in has_responses, rhs in omits_intercepts
-            @test hasresponse(lhs ~ rhs)
-            @test !hasintercept(lhs ~ rhs)
-            @test omitsintercept(lhs ~ rhs)
+            @test T.hasresponse(lhs ~ rhs)
+            @test !T.hasintercept(lhs ~ rhs)
+            @test T.omitsintercept(lhs ~ rhs)
 
-            @test hasresponse(lhs ~ rhs + a)
-            @test !hasintercept(lhs ~ rhs + a)
-            @test omitsintercept(lhs ~ rhs + a)
+            @test T.hasresponse(lhs ~ rhs + a)
+            @test !T.hasintercept(lhs ~ rhs + a)
+            @test T.omitsintercept(lhs ~ rhs + a)
         end
 
         for lhs in no_responses, rhs in omits_intercepts
-            @test !hasresponse(lhs ~ rhs)
-            @test !hasintercept(lhs ~ rhs)
-            @test omitsintercept(lhs ~ rhs)
+            @test !T.hasresponse(lhs ~ rhs)
+            @test !T.hasintercept(lhs ~ rhs)
+            @test T.omitsintercept(lhs ~ rhs)
 
-            @test !hasresponse(lhs ~ rhs + a)
-            @test !hasintercept(lhs ~ rhs + a)
-            @test omitsintercept(lhs ~ rhs + a)
+            @test !T.hasresponse(lhs ~ rhs + a)
+            @test !T.hasintercept(lhs ~ rhs + a)
+            @test T.omitsintercept(lhs ~ rhs + a)
         end
     end
 
     @testset "Tuple terms" begin
-        a, b, c = Term.((:a, :b, :c))
+        a, b, c = T.Term.((:a, :b, :c))
 
         # TermOrTerms - one or more AbstractTerms (if more, a tuple)
         # empty tuples are never terms
-        @test !(() isa TermOrTerms)
-        @test (a,) isa TermOrTerms
-        @test (a, b) isa TermOrTerms
-        @test (a, b, a & b) isa TermOrTerms
-        @test !(((), a) isa TermOrTerms)
+        @test !(() isa T.TermOrTerms)
+        @test (a,) isa T.TermOrTerms
+        @test (a, b) isa T.TermOrTerms
+        @test (a, b, a & b) isa T.TermOrTerms
+        @test !(((), a) isa T.TermOrTerms)
         # can't contain further tuples
-        @test !((a, (a,), b) isa TermOrTerms)
+        @test !((a, (a,), b) isa T.TermOrTerms)
 
         # a tuple of AbstractTerms OR Tuples of one or more terms
         # empty tuples are never terms
-        @test !(() isa TupleTerm)
-        @test (a,) isa TupleTerm
-        @test (a, b) isa TupleTerm
-        @test (a, b, a & b) isa TupleTerm
-        @test !(((), a) isa TupleTerm)
-        @test (((a,), a) isa TupleTerm)
+        @test !(() isa T.TupleTerm)
+        @test (a,) isa T.TupleTerm
+        @test (a, b) isa T.TupleTerm
+        @test (a, b, a & b) isa T.TupleTerm
+        @test !(((), a) isa T.TupleTerm)
+        @test (((a,), a) isa T.TupleTerm)
 
         # no methods for operators on term and empty tuple (=no type piracy)
         @test_throws MethodError a + ()
@@ -198,29 +178,29 @@ mimestring(x) = mimestring(MIME"text/plain", x)
     @testset "concrete_term error messages" begin
         t = (a=[1, 2, 3], b=[0.0, 0.5, 1.0])
         @test Tables.istable(t)
-        @test_throws ArgumentError concrete_term(term(:not_there), t)
+        @test_throws ArgumentError T.concrete_term(T.term(:not_there), t)
     end
 
     @testset "coefnames" begin
         f = @formula y_float ~ 0 + x_int + x_cat
-        sch = schema(f, nt_str)
-        ts = apply_schema(f.rhs, sch)
-        ts = collect_matrix_terms(ts)
-        coef_names = coefnames(ts)
+        sch = T.schema(f, nt_str)
+        ts = T.apply_schema(f.rhs, sch)
+        ts = T.collect_matrix_terms(ts)
+        coef_names = T.coefnames(ts)
         @test coef_names == ["x_int", "x_cat: 2", "x_cat: 3", "x_cat: 4"]
 
         f = @formula y_float ~ 1 + x_int + x_cat
-        sch = schema(f, nt_str)
-        ts = apply_schema(f.rhs, sch)
-        ts = collect_matrix_terms(ts)
-        coef_names = coefnames(ts)
+        sch = T.schema(f, nt_str)
+        ts = T.apply_schema(f.rhs, sch)
+        ts = T.collect_matrix_terms(ts)
+        coef_names = T.coefnames(ts)
         @test coef_names == ["x_int", "x_cat: 2", "x_cat: 3", "x_cat: 4"]
 
         f = @formula y_float ~ 0 + x_float * x_cat_ordered
-        sch = schema(f, nt_cat)
-        ts = apply_schema(f.rhs, sch)
-        ts = collect_matrix_terms(ts)
-        coef_names = coefnames(ts)
+        sch = T.schema(f, nt_cat)
+        ts = T.apply_schema(f.rhs, sch)
+        ts = T.collect_matrix_terms(ts)
+        coef_names = T.coefnames(ts)
         @test coef_names == [
             "x_float",
             "x_cat_ordered: 2",
@@ -232,10 +212,10 @@ mimestring(x) = mimestring(MIME"text/plain", x)
         ]
 
         f = @formula y_float ~ 1 + x_float * x_cat_ordered
-        sch = schema(f, nt_cat)
-        ts = apply_schema(f.rhs, sch)
-        ts = collect_matrix_terms(ts)
-        coef_names = coefnames(ts)
+        sch = T.schema(f, nt_cat)
+        ts = T.apply_schema(f.rhs, sch)
+        ts = T.collect_matrix_terms(ts)
+        coef_names = T.coefnames(ts)
         @test coef_names == [
             "x_float",
             "x_cat_ordered: 2",
@@ -248,10 +228,10 @@ mimestring(x) = mimestring(MIME"text/plain", x)
 
         # Interactions coming first
         f = @formula y_float ~ 1 + x_int * x_cat + x_float
-        sch = schema(f, nt_str)
-        ts = apply_schema(f.rhs, sch)
-        ts = collect_matrix_terms(ts)
-        coef_names = coefnames(ts)
+        sch = T.schema(f, nt_str)
+        ts = T.apply_schema(f.rhs, sch)
+        ts = T.collect_matrix_terms(ts)
+        coef_names = T.coefnames(ts)
         @test coef_names == [
             "x_int",
             "x_cat: 2",
@@ -264,10 +244,10 @@ mimestring(x) = mimestring(MIME"text/plain", x)
         ]
 
         f = @formula y_float ~ 1 + x_int * x_cat_ordered + x_float
-        sch = schema(f, nt_cat)
-        ts = apply_schema(f.rhs, sch)
-        ts = collect_matrix_terms(ts)
-        coef_names = coefnames(ts)
+        sch = T.schema(f, nt_cat)
+        ts = T.apply_schema(f.rhs, sch)
+        ts = T.collect_matrix_terms(ts)
+        coef_names = T.coefnames(ts)
         @test coef_names == [
             "x_int",
             "x_cat_ordered: 2",

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,59 +1,65 @@
 @testset "utils" begin
     @testset "center_predictors" begin
-        # NamedTuples
-        f = @formula(y_int ~ x_float + x_cat)
-        m = TuringGLM.data_fixed_effects(f, nt_str)
-        μ_X, X_centered = TuringGLM.center_predictors(X)
-        @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
-        @test X_centered ≈ [
-            -1.447 -0.25 -0.25 -0.25
-            -0.247 0.75 -0.25 -0.25
-            0.592 -0.25 0.75 -0.25
-            1.102 -0.25 -0.25 0.75
-        ] atol = 0.01
-        @test mapslices(mean, X_centered; dims=1) ≈ [0 0 0 0] atol = 0.01
+        @testset "NamedTuples" begin
+            f = @formula(y_int ~ x_float + x_cat)
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            μ_X, X_centered = TuringGLM.center_predictors(X)
+            @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
+            @test X_centered ≈ [
+                -1.447 -0.25 -0.25 -0.25
+                -0.247 0.75 -0.25 -0.25
+                0.592 -0.25 0.75 -0.25
+                1.102 -0.25 -0.25 0.75
+            ] atol = 0.01
+            @test mapslices(mean, X_centered; dims=1) ≈ [0 0 0 0] atol = 0.01
+        end
 
-        # DataFrames
-        m = TuringGLM.data_fixed_effects(f, df_str)
-        μ_X, X_centered = TuringGLM.center_predictors(X)
-        @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
-        @test X_centered ≈ [
-            -1.447 -0.25 -0.25 -0.25
-            -0.247 0.75 -0.25 -0.25
-            0.592 -0.25 0.75 -0.25
-            1.102 -0.25 -0.25 0.75
-        ] atol = 0.01
-        @test mapslices(mean, X_centered; dims=1) ≈ [0 0 0 0] atol = 0.01
+        @testset "DataFrames" begin
+            f = @formula(y_int ~ x_float + x_cat)
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            μ_X, X_centered = TuringGLM.center_predictors(X)
+            @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
+            @test X_centered ≈ [
+                -1.447 -0.25 -0.25 -0.25
+                -0.247 0.75 -0.25 -0.25
+                0.592 -0.25 0.75 -0.25
+                1.102 -0.25 -0.25 0.75
+            ] atol = 0.01
+            @test mapslices(mean, X_centered; dims=1) ≈ [0 0 0 0] atol = 0.01
+        end
     end
 
     @testset "standardize_predictors" begin
-        # NamedTuples
-        f = @formula(y_int ~ x_float + x_cat)
-        m = TuringGLM.data_fixed_effects(f, nt_str)
-        μ_X, σ_X, X_std = TuringGLM.standardize_predictors(X)
-        @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
-        @test σ_X ≈ [1.114 0.5 0.5 0.5] atol = 0.01
-        @test X_std ≈ [
-            -1.299 -0.5 -0.5 -0.5
-            -0.222 1.5 -0.5 -0.5
-            0.531 -0.5 1.5 -0.5
-            0.989 -0.5 -0.5 1.5
-        ] atol = 0.01
-        @test mapslices(mean, X_std; dims=1) ≈ [0 0 0 0] atol = 0.01
-        @test mapslices(std, X_std; dims=1) ≈ [1 1 1 1] atol = 0.01
+        @testset "NamedTuples" begin
+            f = @formula(y_int ~ x_float + x_cat)
+            X = TuringGLM.data_fixed_effects(f, nt_str)
+            μ_X, σ_X, X_std = TuringGLM.standardize_predictors(X)
+            @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
+            @test σ_X ≈ [1.114 0.5 0.5 0.5] atol = 0.01
+            @test X_std ≈ [
+                -1.299 -0.5 -0.5 -0.5
+                -0.222 1.5 -0.5 -0.5
+                0.531 -0.5 1.5 -0.5
+                0.989 -0.5 -0.5 1.5
+            ] atol = 0.01
+            @test mapslices(mean, X_std; dims=1) ≈ [0 0 0 0] atol = 0.01
+            @test mapslices(std, X_std; dims=1) ≈ [1 1 1 1] atol = 0.01
+        end
 
-        # DataFrames
-        m = TuringGLM.data_fixed_effects(f, df_str)
-        μ_X, σ_X, X_std = TuringGLM.standardize_predictors(X)
-        @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
-        @test σ_X ≈ [1.114 0.5 0.5 0.5] atol = 0.01
-        @test X_std ≈ [
-            -1.299 -0.5 -0.5 -0.5
-            -0.222 1.5 -0.5 -0.5
-            0.531 -0.5 1.5 -0.5
-            0.989 -0.5 -0.5 1.5
-        ] atol = 0.01
-        @test mapslices(mean, X_std; dims=1) ≈ [0 0 0 0] atol = 0.01
-        @test mapslices(std, X_std; dims=1) ≈ [1 1 1 1] atol = 0.01
+        @testset "DataFrames" begin
+            f = @formula(y_int ~ x_float + x_cat)
+            X = TuringGLM.data_fixed_effects(f, df_str)
+            μ_X, σ_X, X_std = TuringGLM.standardize_predictors(X)
+            @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
+            @test σ_X ≈ [1.114 0.5 0.5 0.5] atol = 0.01
+            @test X_std ≈ [
+                -1.299 -0.5 -0.5 -0.5
+                -0.222 1.5 -0.5 -0.5
+                0.531 -0.5 1.5 -0.5
+                0.989 -0.5 -0.5 1.5
+            ] atol = 0.01
+            @test mapslices(mean, X_std; dims=1) ≈ [0 0 0 0] atol = 0.01
+            @test mapslices(std, X_std; dims=1) ≈ [1 1 1 1] atol = 0.01
+        end
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -2,8 +2,8 @@
     @testset "center_predictors" begin
         @testset "NamedTuples" begin
             f = @formula(y_int ~ x_float + x_cat)
-            X = TuringGLM.data_fixed_effects(f, nt_str)
-            μ_X, X_centered = TuringGLM.center_predictors(X)
+            X = T.data_fixed_effects(f, nt_str)
+            μ_X, X_centered = T.center_predictors(X)
             @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
             @test X_centered ≈ [
                 -1.447 -0.25 -0.25 -0.25
@@ -16,8 +16,8 @@
 
         @testset "DataFrames" begin
             f = @formula(y_int ~ x_float + x_cat)
-            X = TuringGLM.data_fixed_effects(f, df_str)
-            μ_X, X_centered = TuringGLM.center_predictors(X)
+            X = T.data_fixed_effects(f, df_str)
+            μ_X, X_centered = T.center_predictors(X)
             @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
             @test X_centered ≈ [
                 -1.447 -0.25 -0.25 -0.25
@@ -32,8 +32,8 @@
     @testset "standardize_predictors" begin
         @testset "NamedTuples" begin
             f = @formula(y_int ~ x_float + x_cat)
-            X = TuringGLM.data_fixed_effects(f, nt_str)
-            μ_X, σ_X, X_std = TuringGLM.standardize_predictors(X)
+            X = T.data_fixed_effects(f, nt_str)
+            μ_X, σ_X, X_std = T.standardize_predictors(X)
             @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
             @test σ_X ≈ [1.114 0.5 0.5 0.5] atol = 0.01
             @test X_std ≈ [
@@ -48,8 +48,8 @@
 
         @testset "DataFrames" begin
             f = @formula(y_int ~ x_float + x_cat)
-            X = TuringGLM.data_fixed_effects(f, df_str)
-            μ_X, σ_X, X_std = TuringGLM.standardize_predictors(X)
+            X = T.data_fixed_effects(f, df_str)
+            μ_X, σ_X, X_std = T.standardize_predictors(X)
             @test μ_X ≈ [2.547 0.25 0.25 0.25] atol = 0.01
             @test σ_X ≈ [1.114 0.5 0.5 0.5] atol = 0.01
             @test X_std ≈ [


### PR DESCRIPTION
This PR adds the `data_response` and `data_fixed_effects` functions that creates the response `y` and matrix `X` from a `@formula` and a Tables.jl-compatible interface.

The tests are mostly done with `NamedTuples` and `DataFrames`.

Related to #2.