### PR TITLE
Run compathelper less often

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,7 +1,7 @@
 name: CompatHelper
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 5
   workflow_dispatch:
 jobs:
   CompatHelper:


### PR DESCRIPTION
The Actions tab is full of CompatHelper runs. Running once a week should be often enough.