### PR TITLE
Set version to 1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TuringGLM"
 uuid = "0004c1f4-53c5-4d43-a221-a1dac6cf6b74"
 authors = ["Jose Storopoli <thestoropoli@gmail.com>, Rik Huijzer <t.h.huijzer@rug.nl>, and contributors"]
-version = "0.1.0"
+version = "1.0.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"


### PR DESCRIPTION
Setting the version to 1.0.0 to allow ourselves to publish MAJOR, MINOR and PATCH releases in the future (see <https://semver.org/> for details). With version 0.1.0, the Julia convention is that a MINOR release is breaking and, uuuuhm, a MAJOR release is very breaking?