### PR TITLE
Set `Turing.setprogress!(false)` for tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ using Random: seed!
 
 const T = TuringGLM
 
+# Decreases running time by about 10%.
+Turing.setprogress!(false)
+
 x_float = [1.1, 2.3, 3.14, 3.65]
 x_int = [1, 2, 3, 4]
 y_float = [2.3, 3.4, 4.5, 5.4]


### PR DESCRIPTION
Reduces running time for the tests. The number, 10% reduction, is based on running the tests locally and seeing it take 392 versus 444 seconds.

```julia
julia> round(((444 - 392) / 444) * 100; digits=1)
11.7
```