### PR TITLE
Set timeout to 90 minutes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: Julia CI
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
CI running time went from 30 minutes to 60 minutes at some point (https://github.com/TuringLang/TuringGLM.jl/actions/workflows/CI.yml).