### PR TITLE
Only specify lower bound of partially truncated distributions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TuringGLM"
 uuid = "0004c1f4-53c5-4d43-a221-a1dac6cf6b74"
 authors = ["Jose Storopoli <thestoropoli@gmail.com>, Rik Huijzer <t.h.huijzer@rug.nl>, and contributors"]
-version = "2.0.1"
+version = "2.1.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -19,7 +19,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
-Distributions = "0.25"
+Distributions = "0.25.42"
 GLM = "1.5"
 LazyArrays = "0.22"
 MixedModels = "4.5"

--- a/src/turing_model.jl
+++ b/src/turing_model.jl
@@ -180,7 +180,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{Normal})
         σ ~ Exponential(residual)
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ mad(y) * truncated(TDist(3), 0, Inf)
+            τ ~ mad(y) * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]
@@ -222,7 +222,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{TDist})
         ν ~ prior.auxiliary
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ 0 + mad(y) * truncated(TDist(3), 0, Inf)
+            τ ~ 0 + mad(y) * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]
@@ -262,7 +262,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{Bernoulli})
         β ~ filldist(prior.predictors, predictors)
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ mad(y) * truncated(TDist(3), 0, Inf)
+            τ ~ mad(y) * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]
@@ -300,7 +300,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{Poisson})
         β ~ filldist(prior.predictors, predictors)
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ mad(y) * truncated(TDist(3), 0, Inf)
+            τ ~ mad(y) * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]
@@ -340,7 +340,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{NegativeBinomial
         ϕ = 1 / ϕ⁻
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ mad(y) * truncated(TDist(3), 0, Inf)
+            τ ~ mad(y) * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]


### PR DESCRIPTION
Support for this was introduced in Distributions 0.25.42. It avoids undesired promotions and improves compatibility with AD (e.g., often the infinite bound is problematic for ForwardDiff in not-NaN-safe mode (the default)).