### PR TITLE
Fix deprecation of keyword argument in `mad`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TuringGLM"
 uuid = "0004c1f4-53c5-4d43-a221-a1dac6cf6b74"
 authors = ["Jose Storopoli <thestoropoli@gmail.com>, Rik Huijzer <t.h.huijzer@rug.nl>, and contributors"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/turing_model.jl
+++ b/src/turing_model.jl
@@ -137,10 +137,12 @@ end
 # Default priors
 _prior(prior::Prior, y, ::Type{<:UnivariateDistribution}) = prior
 function _prior(::DefaultPrior, y, ::Type{Normal})
-    return CustomPrior(TDist(3), median(y) + mad(y) * TDist(3), nothing)
+    m = median(y)
+    return CustomPrior(TDist(3), m + mad(y; center=m, normalize=true) * TDist(3), nothing)
 end
 function _prior(::DefaultPrior, y, ::Type{TDist})
-    return CustomPrior(TDist(3), median(y) + mad(y) * TDist(3), Gamma(2, 0.1))
+    m = median(y)
+    return CustomPrior(TDist(3), m + mad(y; center=m, normalize=true) * TDist(3), Gamma(2, 0.1))
 end
 function _prior(::DefaultPrior, y, ::Type{Bernoulli})
     return CustomPrior(TDist(3), 2.5 * TDist(3), nothing)
@@ -174,13 +176,14 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{Normal})
         σ_X=σ_X,
         prior=prior,
         residual=1 / std(y),
+        mad_y=mad(y; normalize=true),
     )
         α ~ prior.intercept
         β ~ filldist(prior.predictors, predictors)
         σ ~ Exponential(residual)
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ mad(y) * truncated(TDist(3); lower=0)
+            τ ~ mad_y * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]
@@ -215,6 +218,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{TDist})
         σ_X=σ_X,
         prior=prior,
         residual=1 / std(y),
+        mad_y=mad(y; normalize=true),
     )
         α ~ prior.intercept
         β ~ filldist(prior.predictors, predictors)
@@ -222,7 +226,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{TDist})
         ν ~ prior.auxiliary
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ 0 + mad(y) * truncated(TDist(3); lower=0)
+            τ ~ mad_y * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]
@@ -257,12 +261,13 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{Bernoulli})
         μ_X=μ_X,
         σ_X=σ_X,
         prior=prior,
+        mad_y=mad(y; normalize=true),
     )
         α ~ prior.intercept
         β ~ filldist(prior.predictors, predictors)
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ mad(y) * truncated(TDist(3); lower=0)
+            τ ~ mad_y * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]
@@ -295,12 +300,13 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{Poisson})
         μ_X=μ_X,
         σ_X=σ_X,
         prior=prior,
+        mad_y=mad(y; normalize=true),
     )
         α ~ prior.intercept
         β ~ filldist(prior.predictors, predictors)
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ mad(y) * truncated(TDist(3); lower=0)
+            τ ~ mad_y * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]
@@ -333,6 +339,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{NegativeBinomial
         μ_X=μ_X,
         σ_X=σ_X,
         prior=prior,
+        mad_y=mad(y; normalize=true),
     )
         α ~ prior.intercept
         β ~ filldist(prior.predictors, predictors)
@@ -340,7 +347,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{NegativeBinomial
         ϕ = 1 / ϕ⁻
         μ = α .+ X * β
         if !isempty(intercept_ranef)
-            τ ~ mad(y) * truncated(TDist(3); lower=0)
+            τ ~ mad_y * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             αⱼ = zⱼ .* τ
             μ .+= αⱼ[idxs]

--- a/src/turing_model.jl
+++ b/src/turing_model.jl
@@ -142,7 +142,9 @@ function _prior(::DefaultPrior, y, ::Type{Normal})
 end
 function _prior(::DefaultPrior, y, ::Type{TDist})
     m = median(y)
-    return CustomPrior(TDist(3), m + mad(y; center=m, normalize=true) * TDist(3), Gamma(2, 0.1))
+    return CustomPrior(
+        TDist(3), m + mad(y; center=m, normalize=true) * TDist(3), Gamma(2, 0.1)
+    )
 end
 function _prior(::DefaultPrior, y, ::Type{Bernoulli})
     return CustomPrior(TDist(3), 2.5 * TDist(3), nothing)


### PR DESCRIPTION
That deprecation has existed since 2018 (StatsBase 0.20.1) apparently. By default, `mad` computes a normalized version of the MAD such that it becomes a consistent estimator of the standard deviation under normality assumptions (https://juliastats.org/StatsBase.jl/latest/scalarstats/#StatsBase.mad). If this was not desired here, `normalize` should be set to `false`.