### PR TITLE
add links in documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,15 +58,7 @@ Currently, for likelihoods `TuringGLM.jl` supports:
 
 ## Tutorials
 
-Take a look at the tutorials for all supported likelihood and models:
-
-* [Linear Regression](tutorials/linear_regression)
-* [Logistic Regression](tutorials/logistic_regression)
-* [Poisson Regression](tutorials/poisson_regression)
-* [Negative Binomial Regression](tutorials/negativebinomial_regression)
-* [Robust Student-t Regression](tutorials/robust_regression)
-* [Hierarchical Models](tutorials/hierarchical_models)
-* [Custom Priors](tutorials/custom_prior)
+Take a look at the tutorials for all supported likelihood and models.
 
 ```@contents
 Pages = [

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,7 @@
 # TuringGLM
 
 Documentation for [TuringGLM](https://github.com/TuringLang/TuringGLM.jl).
-Please [file an issue](https://github.com/TuringLang/TuringGLM.jl/issues/new) 
+Please [file an issue](https://github.com/TuringLang/TuringGLM.jl/issues/new)
 if you run into any problems.
 
 ## Getting Started
@@ -59,6 +59,14 @@ Currently, for likelihoods `TuringGLM.jl` supports:
 ## Tutorials
 
 Take a look at the tutorials for all supported likelihood and models:
+
+* [Linear Regression](tutorials/linear_regression)
+* [Logistic Regression](tutorials/logistic_regression)
+* [Poisson Regression](tutorials/poisson_regression)
+* [Negative Binomial Regression](tutorials/negativebinomial_regression)
+* [Robust Student-t Regression](tutorials/robust_regression)
+* [Hierarchical Models](tutorials/hierarchical_models)
+* [Custom Priors](tutorials/custom_prior)
 
 ```@contents
 Pages = [


### PR DESCRIPTION
Currently we don't have a very intuitive followup in the bottom of the main page of the docs:
![image](https://user-images.githubusercontent.com/43353831/188515301-232a3bcb-a9e8-411f-9f07-b0946170dbce.png)

This PR adds the tutorials links in an unordered list.

@rikhuijzer you have more experience with documentation. Could you please review it? (not urgent). Specially the links.