### PR TITLE
Make `has_ranef` robust to univariate RHS

### DIFF
--- a/src/data_constructors.jl
+++ b/src/data_constructors.jl
@@ -97,7 +97,11 @@ Returns `true` if any of the terms in `formula` is a `FunctionTerm` or false
 otherwise.
 """
 function has_ranef(formula::FormulaTerm)
-    return any(t -> t isa FunctionTerm{typeof(|)}, formula.rhs)
+    if formula.rhs isa StatsModels.Term
+        return false
+    else
+        return any(t -> t isa FunctionTerm{typeof(|)}, formula.rhs)
+    end
 end
 
 """


### PR DESCRIPTION
Trying the most simple linear regression model today I noticed that `turing_model(@formula(y ~ x), data)` fails, as `has_ranef` tries to iterate over `formula.rhs`, which does not work if there's only one term on the RHS.

Chatting with @kleinschmidt on Slack there might be something that could be done on the `StatsModels` end, but this would potentially be disruptive and currently no one has the bandwidth to work on such a change, so for now I've made a simple change to `has_ranef` which fixes this on the `TuringGLM.jl` end, which I'll PR shortly. 

As a single term cannot be a random effect (I believe!) `has_ranef` should return `false` for a single RHS variable. 

Tests pass locally for this change but I assume this isn't surprising given that the change only affects univariate regressions which clearly hadn't been in the test suite before. 