### PR TITLE
fix: τ priors for hierarchical Bernoulli models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TuringGLM"
 uuid = "0004c1f4-53c5-4d43-a221-a1dac6cf6b74"
 authors = ["Jose Storopoli <jose@storopoli.io>, Rik Huijzer <t.h.huijzer@rug.nl>, and contributors"]
-version = "2.5"
+version = "2.6"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/turing_model.jl
+++ b/src/turing_model.jl
@@ -263,14 +263,14 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{Bernoulli})
         μ_X=μ_X,
         σ_X=σ_X,
         prior=prior,
-        mad_y=mad(y; normalize=true),
+        std_y=std(y; normalize=true),
     )
         α ~ prior.intercept
         β ~ filldist(prior.predictors, predictors)
         if isempty(intercept_ranef)
             μ = α .+ X * β
         else
-            τ ~ mad_y * truncated(TDist(3); lower=0)
+            τ ~ std_y * truncated(TDist(3); lower=0)
             zⱼ ~ filldist(Normal(), n_gr)
             μ = α .+ τ .* getindex.((zⱼ,), idxs) .+ X * β
         end


### PR DESCRIPTION
Closes #83 and tags a new version