### PR TITLE
Remove `normalize` from `std` call

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1
+          - '1.10'
         os:
           - ubuntu-latest
           - windows-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TuringGLM"
 uuid = "0004c1f4-53c5-4d43-a221-a1dac6cf6b74"
 authors = ["Jose Storopoli <jose@storopoli.io>", "Rik Huijzer <t.h.huijzer@rug.nl>", "contributors"]
-version = "2.12.0"
+version = "2.12.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/turing_model.jl
+++ b/src/turing_model.jl
@@ -263,7 +263,7 @@ function _model(μ_X, σ_X, prior, intercept_ranef, idx, ::Type{Bernoulli})
         μ_X=μ_X,
         σ_X=σ_X,
         prior=prior,
-        std_y=std(y; normalize=true),
+        std_y=std(y),
     )
         α ~ prior.intercept
         β ~ filldist(prior.predictors, predictors)


### PR DESCRIPTION
Fixes https://github.com/TuringLang/TuringGLM.jl/issues/149. I didn't run the tests locally so let's see whether CI succeeds.

It looks like the `normalize` was accidentally added during some refactoring. The file also calls `mad` often and `mad` does have a `normalize` keyword.

